### PR TITLE
disable nginx default site

### DIFF
--- a/explain.pp
+++ b/explain.pp
@@ -102,6 +102,13 @@ server {
     require => Package['nginx'],
 }
 
+file { '/etc/nginx/sites-enabled/default':
+    ensure => "absent",
+    purge => true,
+    notify  => Service['nginx'],
+    require => Package['nginx'],
+}
+
 
 service { 'nginx':
     ensure => running,


### PR DESCRIPTION
This enables access to vm hosted explain.depesz.com without
intervention following vagrant provisioning.